### PR TITLE
Add hosted mode with RFC 9728 OAuth discovery

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,3 +29,21 @@ STRATO_API_BASE_URL=https://buildtest.mercata-testnet.blockapps.net/api
 #GRIPHOOK_HTTP_HOST=127.0.0.1
 #GRIPHOOK_HTTP_PORT=3005
 #GRIPHOOK_HTTP_PATH=/mcp
+
+# ============================================================================
+# Hosted Mode (Multi-user deployment)
+# ============================================================================
+
+# When GRIPHOOK_PUBLIC_URL is set, the server runs in hosted mode:
+# - Requires Bearer token authentication on all MCP endpoints
+# - Exposes /.well-known/oauth-protected-resource for RFC 9728 OAuth discovery
+# - MCP clients with OAuth support can authenticate automatically
+#
+# For local development, leave this unset.
+# For production deployment, set this to your public URL.
+#GRIPHOOK_PUBLIC_URL=https://griphook.strato.nexus
+
+# Optional: Override OAuth client for hosted mode (defaults to OAUTH_CLIENT_ID/SECRET)
+# Useful when the hosted server needs different redirect URIs than local login.
+#GRIPHOOK_HOSTED_CLIENT_ID=griphook-hosted
+#GRIPHOOK_HOSTED_CLIENT_SECRET=your-hosted-client-secret

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import "dotenv/config";
-import { loginCommand, logoutCommand, statusCommand, getCredentialsPath } from "./login.js";
+import { loginCommand, logoutCommand, statusCommand, tokenCommand, getCredentialsPath } from "./login.js";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -15,12 +15,17 @@ Commands:
   login     Authenticate with BlockApps via browser
   logout    Clear stored credentials
   status    Show current authentication status
+  token     Print Bearer token for MCP client configuration
   serve     Start the MCP server (default)
   help      Show this help message
 
 Authentication:
   Run 'griphook login' to authenticate via browser OAuth.
   Credentials are stored in: ${getCredentialsPath()}
+
+Token for remote MCP servers:
+  Run 'griphook token' to get a Bearer token for configuring
+  MCP clients that don't support OAuth (e.g., Cursor, Cline).
 
 For MCP server configuration, see the documentation.
 `);
@@ -38,6 +43,10 @@ async function main(): Promise<void> {
 
     case "status":
       statusCommand();
+      break;
+
+    case "token":
+      await tokenCommand(args.includes("--json"));
       break;
 
     case "serve":

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,16 +1,104 @@
 import "dotenv/config";
 import { createRequire } from "module";
+import type { Request, Response, NextFunction } from "express";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { loadConfig } from "./config.js";
+import { loadConfig, GriphookConfig } from "./config.js";
 import { GriphookClient } from "./client.js";
 import { registerTools } from "./tools.js";
 import { registerResources } from "./resources.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
+
+/**
+ * RFC 9728 Protected Resource Metadata
+ * https://datatracker.ietf.org/doc/html/rfc9728
+ */
+function getProtectedResourceMetadata(config: GriphookConfig) {
+  if (!config.hosted || !config.oauth) return null;
+
+  // Extract authorization server URL from OpenID discovery URL
+  // e.g., https://keycloak.blockapps.net/auth/realms/mercata/.well-known/openid-configuration
+  // -> https://keycloak.blockapps.net/auth/realms/mercata
+  const authServer = config.oauth.openIdDiscoveryUrl.replace("/.well-known/openid-configuration", "");
+
+  return {
+    resource: `${config.hosted.publicUrl}${config.http.path}`,
+    authorization_servers: [authServer],
+    scopes_supported: ["openid", "email", "profile"],
+    bearer_methods_supported: ["header"],
+    resource_documentation: "https://github.com/strato-net/strato-griphook",
+  };
+}
+
+/**
+ * Build WWW-Authenticate header value for 401 responses
+ */
+function buildWwwAuthenticateHeader(config: GriphookConfig): string {
+  const metadataUrl = `${config.hosted!.publicUrl}/.well-known/oauth-protected-resource`;
+  return `Bearer resource_metadata="${metadataUrl}"`;
+}
+
+/**
+ * Express middleware to verify Bearer token in hosted mode.
+ * In hosted mode, requests must include a valid Bearer token.
+ * The token is validated by making a request to the STRATO API.
+ */
+function createHostedAuthMiddleware(config: GriphookConfig) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    // Skip auth for well-known endpoints
+    if (req.path.startsWith("/.well-known/")) {
+      return next();
+    }
+
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401)
+        .set("WWW-Authenticate", buildWwwAuthenticateHeader(config))
+        .json({
+          error: "unauthorized",
+          error_description: "Bearer token required. See WWW-Authenticate header for OAuth metadata.",
+        });
+      return;
+    }
+
+    const token = authHeader.slice(7); // Remove "Bearer " prefix
+
+    // Validate token by making a test request to STRATO API
+    // This also ensures the token has access to STRATO resources
+    try {
+      const response = await fetch(`${config.apiBaseUrl}/tokens/balance`, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) {
+        res.status(401)
+          .set("WWW-Authenticate", buildWwwAuthenticateHeader(config))
+          .json({
+            error: "invalid_token",
+            error_description: "Token is invalid or expired",
+          });
+        return;
+      }
+
+      // Attach token to request for downstream use
+      (req as any).stratoToken = token;
+      next();
+    } catch (err) {
+      res.status(401)
+        .set("WWW-Authenticate", buildWwwAuthenticateHeader(config))
+        .json({
+          error: "invalid_token",
+          error_description: "Failed to validate token",
+        });
+    }
+  };
+}
 
 function buildServer(config: ReturnType<typeof loadConfig>) {
   const instructions = [
@@ -49,7 +137,32 @@ async function startHttpServer(config: ReturnType<typeof loadConfig>) {
   const transport = new StreamableHTTPServerTransport();
   await server.connect(transport);
 
-  const app = createMcpExpressApp({ host: config.http.host });
+  // In hosted mode, we need to allow the public hostname in addition to localhost
+  const allowedHosts = config.hosted
+    ? [config.http.host, "localhost", "127.0.0.1", new URL(config.hosted.publicUrl).hostname]
+    : undefined;
+  const app = createMcpExpressApp({ host: config.http.host, allowedHosts });
+
+  // In hosted mode, add OAuth discovery and auth middleware
+  if (config.hosted) {
+    // RFC 9728 Protected Resource Metadata endpoint
+    app.get("/.well-known/oauth-protected-resource", (_req, res) => {
+      const metadata = getProtectedResourceMetadata(config);
+      if (!metadata) {
+        res.status(503).json({ error: "OAuth not configured" });
+        return;
+      }
+      res.json(metadata);
+    });
+
+    // Apply auth middleware to MCP endpoints
+    app.use(config.http.path, createHostedAuthMiddleware(config));
+    app.use(config.http.ssePath, createHostedAuthMiddleware(config));
+
+    console.log(`Hosted mode enabled: ${config.hosted.publicUrl}`);
+    console.log(`OAuth metadata: ${config.hosted.publicUrl}/.well-known/oauth-protected-resource`);
+  }
+
   app.post(config.http.path, (req, res) => transport.handleRequest(req, res, (req as any).body));
   app.get(config.http.ssePath, (req, res) => transport.handleRequest(req, res));
 


### PR DESCRIPTION
Enables multi-user deployment where a single Griphook instance serves multiple users who authenticate with their own STRATO credentials.

Features:
- GRIPHOOK_PUBLIC_URL env var enables hosted mode
- RFC 9728 Protected Resource Metadata at /.well-known/oauth-protected-resource
- 401 + WWW-Authenticate header for unauthenticated requests
- Bearer token validation against STRATO API
- `griphook token` command outputs Bearer token for manual config

Hosted mode workflow:
1. Set GRIPHOOK_PUBLIC_URL=https://your-domain.com
2. MCP clients connect to /mcp endpoint
3. Clients with OAuth support (VS Code, Windsurf, OpenCode) auto-authenticate
4. Clients without OAuth use `griphook token` to get Bearer token manually

New environment variables:
- GRIPHOOK_PUBLIC_URL: Public URL (enables hosted mode when set)
- GRIPHOOK_HOSTED_CLIENT_ID: OAuth client ID for hosted mode
- GRIPHOOK_HOSTED_CLIENT_SECRET: OAuth client secret for hosted mode

Files changed:
- src/config.ts: Added HostedConfig type and loadHostedConfig()
- src/server.ts: Added OAuth metadata endpoint and auth middleware
- src/login.ts: Added tokenCommand() for Bearer token output
- src/cli.ts: Added `token` command
- .env.sample: Documented hosted mode variables
- docs/setup.md: Full hosted mode documentation

Local mode (stdio + local HTTP) remains unchanged - hosted mode only activates when GRIPHOOK_PUBLIC_URL is set.