### PR TITLE
Fix error message formatting to handle nested STRATO error objects

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6,6 +6,24 @@ import { getRequestAccessToken } from "./requestContext.js";
 
 export type HttpMethod = "get" | "post" | "put" | "patch" | "delete";
 
+/**
+ * STRATO API error response structure
+ */
+interface StratoErrorResponse {
+  error?: {
+    message?: string;
+    status?: number;
+    type?: string;
+    details?: {
+      code?: string;
+      hint?: string;
+      details?: string;
+      path?: string;
+    };
+  };
+  message?: string;
+}
+
 export class GriphookClient {
   private http: AxiosInstance;
   private oauth: OAuthClient;
@@ -54,14 +72,72 @@ export class GriphookClient {
     return this.oauth.getUsername();
   }
 
+  /**
+   * Format Axios errors into detailed, actionable error messages.
+   * Handles STRATO's nested error response structure:
+   * - StratoError: { error: { message, status, type } }
+   * - CirrusError: { error: { message, status, type, details: { code, hint } } }
+   * - ValidationError, AuthError, etc.
+   */
   private formatAxiosError(err: unknown): string {
-    if (axios.isAxiosError(err)) {
-      const axiosErr = err as AxiosError<{ error?: string; message?: string }>;
-      const status = axiosErr.response?.status;
-      const detail = axiosErr.response?.data?.error || axiosErr.response?.data?.message;
-      return `HTTP ${status ?? "request failed"}: ${detail || axiosErr.message}`;
+    if (!axios.isAxiosError(err)) {
+      return err instanceof Error ? err.message : "Unknown error";
     }
 
-    return err instanceof Error ? err.message : "Unknown error";
+    const axiosErr = err as AxiosError<StratoErrorResponse>;
+    const status = axiosErr.response?.status;
+    const data = axiosErr.response?.data;
+
+    // No response data - network error or timeout
+    if (!data) {
+      if (axiosErr.code === "ECONNABORTED") {
+        return `Request timeout: The server took too long to respond`;
+      }
+      if (axiosErr.code === "ENOTFOUND" || axiosErr.code === "ECONNREFUSED") {
+        return `Connection failed: Unable to reach the STRATO API`;
+      }
+      return `Network error: ${axiosErr.message}`;
+    }
+
+    // Handle nested error object from STRATO backend
+    const errorObj = data.error;
+    if (typeof errorObj === "object" && errorObj !== null) {
+      const parts: string[] = [];
+
+      // Error type (StratoError, CirrusError, ValidationError, etc.)
+      if (errorObj.type) {
+        parts.push(`[${errorObj.type}]`);
+      }
+
+      // Main error message
+      if (errorObj.message) {
+        parts.push(errorObj.message);
+      }
+
+      // Additional details for CirrusError (database errors)
+      if (errorObj.details) {
+        const { code, hint, details: extraDetails } = errorObj.details;
+        if (code) parts.push(`(code: ${code})`);
+        if (hint) parts.push(`Hint: ${hint}`);
+        if (extraDetails) parts.push(`Details: ${extraDetails}`);
+      }
+
+      if (parts.length > 0) {
+        return `HTTP ${status}: ${parts.join(" ")}`;
+      }
+    }
+
+    // Handle plain string error
+    if (typeof errorObj === "string") {
+      return `HTTP ${status}: ${errorObj}`;
+    }
+
+    // Fallback to top-level message
+    if (data.message) {
+      return `HTTP ${status}: ${data.message}`;
+    }
+
+    // Last resort - use axios message
+    return `HTTP ${status ?? "request failed"}: ${axiosErr.message}`;
   }
 }


### PR DESCRIPTION
## Summary

- Fix `[object Object]` being displayed instead of actual error messages
- Properly extract error messages from STRATO's nested response format
- Add error type labels for better debugging

## Problem

The STRATO backend returns errors in this format:
```json
{
  "error": {
    "message": "Actual error message here",
    "status": 400,
    "type": "StratoError"
  }
}
```

The previous code tried to use `data.error` directly as a string, resulting in `[object Object]`.

## Solution

Added proper handling for the nested error structure:
- Extract `error.message` from nested object
- Include `error.type` (StratoError, CirrusError, ValidationError, etc.)
- Handle CirrusError details (code, hint)
- Better messages for network errors

## Example Outputs

Before:
```
HTTP 500: [object Object]
```

After:
```
HTTP 400: [StratoError] Insufficient allowance for transfer
HTTP 400: [CirrusError] Query failed (code: 42P01) Hint: Check table exists
HTTP 401: [AuthError] Invalid or expired token
Request timeout: The server took too long to respond
```

## Test Plan

- [ ] Execute a swap with insufficient allowance - verify error message shows actual reason
- [ ] Trigger a validation error - verify type is shown
- [ ] Test with network timeout - verify friendly message

🤖 Generated with [Claude Code](https://claude.ai/code)