### PR TITLE
feat(auth): support active OAuth access tokens in hosted Griphook mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,10 @@ Set `GRIPHOOK_PUBLIC_URL` to enable multi-user deployment with per-request authe
 GRIPHOOK_PUBLIC_URL=https://griphook.testnet.strato.nexus npm start
 ```
 
-The server exposes `/.well-known/oauth-protected-resource` (RFC 9728). MCP clients with OAuth support authenticate automatically. For clients without OAuth support, visit `/login` to get a Bearer token.
+The server exposes `/.well-known/oauth-protected-resource` (RFC 9728). MCP clients with OAuth support authenticate automatically.  
+Hosted mode accepts either:
+- a user access token (JWT) from an active OAuth session, or
+- a refresh token (from `/login`) which the server exchanges for an access token.
 
 See [deployment guide](https://github.com/strato-net/strato-griphook/issues/1) for full setup including Keycloak, DNS, nginx, and SSL configuration.
 
@@ -127,7 +130,7 @@ See [deployment guide](https://github.com/strato-net/strato-griphook/issues/1) f
 
 ## AI Coding Tool Compatibility
 
-Griphook works with any MCP-enabled AI coding tool. All tools use the same authentication flow: sign in at `/login` to get a token, then add it to your tool's config.
+Griphook works with any MCP-enabled AI coding tool. You can either reuse an active OAuth access token, or sign in at `/login` to get a token for tool configuration.
 
 ### Supported Tools
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.25.2",
         "axios": "^1.13.2",
         "dotenv": "^17.2.3",
+        "jose": "^6.1.2",
         "open": "^10.1.0",
         "zod": "^4.3.5"
       },
@@ -24,6 +25,9 @@
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@modelcontextprotocol/sdk": "^1.25.2",
     "axios": "^1.13.2",
     "dotenv": "^17.2.3",
+    "jose": "^6.1.2",
     "open": "^10.1.0",
     "zod": "^4.3.5"
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { registerTools } from "./tools.js";
 import { registerResources } from "./resources.js";
 import { requestContext } from "./requestContext.js";
 import axios from "axios";
+import { createRemoteJWKSet, jwtVerify } from "jose";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json") as { version: string };
@@ -55,9 +56,51 @@ const pendingLogins = new Map<string, { verifier: string; expiresAt: number }>()
  * Stores: { accessToken, expiresAt }
  */
 const accessTokenCache = new Map<string, { accessToken: string; expiresAt: number }>();
+const verifiedAccessTokenCache = new Map<string, number>();
+const jwksVerifierCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
 
 /** Buffer time before expiry to trigger refresh (1 minute) */
 const TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
+
+function looksLikeJwt(token: string): boolean {
+  return token.split(".").length === 3;
+}
+
+async function verifyBearerAccessToken(
+  accessToken: string,
+  config: GriphookConfig,
+): Promise<boolean> {
+  if (!config.oauth) return false;
+
+  const tokenCacheKey = createHash("sha256").update(accessToken).digest("hex");
+  const cachedUntil = verifiedAccessTokenCache.get(tokenCacheKey);
+  if (cachedUntil && Date.now() < cachedUntil - TOKEN_REFRESH_BUFFER_MS) {
+    return true;
+  }
+
+  try {
+    const oidcConfig = await axios.get(config.oauth.openIdDiscoveryUrl, { timeout: 10000 });
+    const jwksUri = oidcConfig.data.jwks_uri as string | undefined;
+    if (!jwksUri) {
+      return false;
+    }
+
+    let jwks = jwksVerifierCache.get(jwksUri);
+    if (!jwks) {
+      jwks = createRemoteJWKSet(new URL(jwksUri));
+      jwksVerifierCache.set(jwksUri, jwks);
+    }
+
+    const { payload } = await jwtVerify(accessToken, jwks, {
+      clockTolerance: 5,
+    });
+    const expiresAt = payload.exp ? payload.exp * 1000 : Date.now() + (5 * 60 * 1000);
+    verifiedAccessTokenCache.set(tokenCacheKey, expiresAt);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Generate PKCE code verifier and challenge
@@ -1014,8 +1057,9 @@ async function getAccessTokenFromRefresh(
 
 /**
  * Express middleware to verify Bearer token in hosted mode.
- * In hosted mode, requests must include a valid refresh token.
- * The middleware exchanges the refresh token for an access token.
+ * In hosted mode, requests must include either:
+ * - a valid user access token (JWT), or
+ * - a refresh token that can be exchanged for an access token.
  */
 function createHostedAuthMiddleware(config: GriphookConfig) {
   return async (req: Request, res: Response, next: NextFunction) => {
@@ -1036,17 +1080,23 @@ function createHostedAuthMiddleware(config: GriphookConfig) {
       return;
     }
 
-    const refreshToken = authHeader.slice(7); // Remove "Bearer " prefix
+    const bearerToken = authHeader.slice(7); // Remove "Bearer " prefix
 
-    // Exchange refresh token for access token
-    const result = await getAccessTokenFromRefresh(refreshToken, config);
+    let result: { accessToken: string } | { error: string };
+
+    // Prefer direct access-token mode for active logged-in browser sessions.
+    if (looksLikeJwt(bearerToken) && await verifyBearerAccessToken(bearerToken, config)) {
+      result = { accessToken: bearerToken };
+    } else {
+      result = await getAccessTokenFromRefresh(bearerToken, config);
+    }
 
     if ("error" in result) {
       res.status(401)
         .set("WWW-Authenticate", buildWwwAuthenticateHeader(config))
         .json({
           error: "invalid_token",
-          error_description: result.error,
+          error_description: `${result.error}. Provide either a valid access token or a refresh token.`,
         });
       return;
     }


### PR DESCRIPTION
## Summary
This PR updates hosted Griphook authentication to support **active OAuth access tokens** directly, while preserving existing refresh-token behavior.

## What Changed
- In hosted auth middleware, Bearer credentials now support two paths:
  1. **Access token mode** (JWT)
     - Detect JWT-shaped bearer values.
     - Verify signature using OIDC JWKS (`jose` + remote JWKS resolver).
     - Cache verification-by-token hash until expiry.
     - Use verified access token directly for downstream STRATO calls.
  2. **Refresh token mode** (existing behavior)
     - Fallback exchange refresh token -> access token via token endpoint.
- Added in-memory caches for:
  - verified JWT expirations
  - remote JWKS verifier instances
- Updated error wording to clarify accepted credential forms.
- Updated README hosted-mode auth docs to reflect dual-mode bearer handling.
- Added dependency: `jose`.

## Why
Mercata now proxies MCP calls using the active user session token. Griphook needed first-class support for direct access-token auth so users are not forced through manual `/login` token copy workflows.

## Compatibility
- Backward compatible with existing `/login` refresh-token flow.
- Clients that already send refresh token Bearers continue to work.

## Testing
- Ran: `npm run typecheck` (pass).
- Lockfile updated (`npm install --package-lock-only`).

## Notes / Follow-ups
- Current JWT verification intentionally validates signature/expiry and issuer metadata via OIDC JWKS; can be extended with stricter audience checks if required by deployment policy.
